### PR TITLE
fix: HTTP Origin header didn't match request.base_url

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -26,6 +26,9 @@ server {
         proxy_set_header  Host             $http_host;
         proxy_set_header  X-Real-IP        $remote_addr;
         proxy_set_header  X-Forwarded-For  $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Proto $scheme;
+        proxy_set_header  X-Forwarded-Ssl on; # Optional
+        proxy_set_header  X-Forwarded-Port $server_port;
 
         if (!-f $request_filename) {
             proxy_pass http://app;


### PR DESCRIPTION
HTTP Origin header (https://xxx.com) didn't match request.base_url (http://xxx.com)