### PR TITLE
iOS获取更大像素的图标和删除安装包优化

### DIFF
--- a/lib/parsers/pkg_adapter/ipa.rb
+++ b/lib/parsers/pkg_adapter/ipa.rb
@@ -29,7 +29,11 @@ module PkgAdapter
             app_icon_name = @plist["CFBundleIcons~ipad"]["CFBundlePrimaryIcon"]["CFBundleIconName"]
           end
 
-          entry = zip_file.glob("Payload/*.app/#{app_icon_name}[6,4]0x[6,4]0@*.png").last
+          #尝试获取180px的图标
+          entry = zip_file.glob("Payload/*.app/#{app_icon_name}60x60@3x.png").last
+          if entry == nil
+            entry = zip_file.glob("Payload/*.app/#{app_icon_name}[6,4]0x[6,4]0@*.png").last
+          end
           
           if entry
             @app_icon = "#{path}/#{entry.name}"


### PR DESCRIPTION
1、iOS优先获取60x60@3x的图标；
2、删除安装包时，硬删除App图标，并将安装包文件移到backup目录，然后可根据自己逻辑定时清理删除的安装包文件。